### PR TITLE
Bugfix: set up whole scene on turn_on

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,5 @@
+{
+  "name": "sp108e_ws2815",
+  "content_in_root": true,
+  "render_readme": true
+}

--- a/manifest.json
+++ b/manifest.json
@@ -9,5 +9,5 @@
   "homekit": {},
   "dependencies": [],
   "codeowners": ["@samhstein"],
-  "version": "0.2.0"
+  "version": "0.2.1"
 }

--- a/pyledshop/WifiLedShopLight.py
+++ b/pyledshop/WifiLedShopLight.py
@@ -120,28 +120,28 @@ class WifiLedShopLight(LightEntity):
         self.toggle()
 
   def turn_on(self, **kwargs):
+    for k, v in kwargs.items():
+      if k == ATTR_BRIGHTNESS:
+        self.set_brightness(v)
 
-    if ATTR_BRIGHTNESS in kwargs:
-        self.set_brightness(kwargs[ATTR_BRIGHTNESS])
-        return
-
-    if ATTR_HS_COLOR in kwargs:
-        r,g,b = color_util.color_hs_to_RGB(*kwargs[ATTR_HS_COLOR])
+      elif k == ATTR_HS_COLOR:
+        r, g, b = color_util.color_hs_to_RGB(*v)
         self.set_color(r, g, b)
-        return
 
-    if ATTR_WHITE in kwargs:
-        self.set_white(kwargs[ATTR_WHITE])
-        return
+      # ordered after color so that white will override color. Generally don't do this.
+      elif k == ATTR_WHITE:
+        self.set_white(v)
 
-    if ATTR_EFFECT in kwargs:
-        self.set_effect(kwargs[ATTR_EFFECT])
-        return
+      elif k == ATTR_EFFECT:
+        self.set_effect(v)
+
+      else:
+        print(f"unknown control key: {k}")
 
     if not self._state.is_on:
-        self.toggle()
+      self.toggle()
     else:
-        print('already on')
+      print("already on")
 
   def turn_off(self):
     if self._state.is_on:


### PR DESCRIPTION
I noticed that I couldn't set up scenes with presets, and it turned out that it was because when `turn_on` was called with >1 kwarg it was only passing through the brightness one and then returning.

This PR fixes that.

Because I'm using HACS to install this, I also added HACS metadata.