### PR TITLE
Adicionar detecção automática e reconexão de dispositivos (v0.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ Tested with:
 - 100+ preset effects (color chase, fire, rainbow, etc.)
 - Default effect and speed configuration via the UI
 - Supports multiple controllers
+- **Automatic device discovery and reconnection** (v0.6.0+)
+- **Real-time availability tracking** (v0.6.0+)
+
+---
+
+## 🆕 What's New in v0.6.0
+
+### Automatic Device Detection & Reconnection
+
+The integration now automatically detects when your SP108E device comes back online:
+
+- **No more manual restarts**: When you power on a previously offline device, it will automatically become available in Home Assistant within 30 seconds
+- **Smart polling**: The integration polls your device every 30 seconds to check availability
+- **Real-time status**: Devices show as "Available" or "Unavailable" based on actual connectivity
+- **Improved error handling**: Better logging and error recovery for network issues
+
+This solves the common issue where devices wouldn't appear until Home Assistant was restarted.
 
 ---
 

--- a/__init__.py
+++ b/__init__.py
@@ -5,6 +5,8 @@ import asyncio
 from .options_flow import OptionsFlowHandler
 
 from .const import DOMAIN
+from .coordinator import SP108ECoordinator
+from .pyledshop import WifiLedShopLight
 
 PLATFORMS = ["light"]
 
@@ -17,9 +19,31 @@ async def async_setup(hass: HomeAssistant, config: dict):
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up sp108e_ws2815 from a config entry."""
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = entry.data.get('host')
+
+    # Get configuration
+    host = entry.data["host"]
+    name = entry.data["name"]
+    config = {**entry.data, **entry.options}
+
+    # Create the light device instance
+    light = await hass.async_add_executor_job(WifiLedShopLight, host, name, config)
+
+    # Create coordinator for automatic polling
+    coordinator = SP108ECoordinator(hass, light)
+
+    # Fetch initial data
+    await coordinator.async_config_entry_first_refresh()
+
+    # Store coordinator and light for access by platform
+    hass.data[DOMAIN][entry.entry_id] = {
+        "coordinator": coordinator,
+        "light": light,
+    }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Register update listener for options changes
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
     return True
 
@@ -38,6 +62,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Reload config entry when options change."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
 
 async def async_get_options_flow(config_entry):
     return OptionsFlowHandler(config_entry)

--- a/coordinator.py
+++ b/coordinator.py
@@ -1,0 +1,42 @@
+"""DataUpdateCoordinator for SP108E WS2815."""
+from datetime import timedelta
+import logging
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .pyledshop import WifiLedShopLight
+
+_LOGGER = logging.getLogger(__name__)
+
+# Polling interval - check device status every 30 seconds
+UPDATE_INTERVAL = timedelta(seconds=30)
+
+
+class SP108ECoordinator(DataUpdateCoordinator):
+    """Class to manage fetching SP108E data."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        light: WifiLedShopLight,
+    ) -> None:
+        """Initialize coordinator."""
+        self.light = light
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="SP108E WS2815",
+            update_interval=UPDATE_INTERVAL,
+        )
+
+    async def _async_update_data(self):
+        """Fetch data from SP108E device."""
+        try:
+            # Run the blocking update() method in executor
+            await self.hass.async_add_executor_job(self.light.update)
+            return True
+        except Exception as err:
+            # Device is offline or unreachable
+            raise UpdateFailed(f"Error communicating with device: {err}") from err

--- a/light.py
+++ b/light.py
@@ -1,7 +1,22 @@
+"""Light platform for SP108E WS2815."""
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_HS_COLOR,
+    ATTR_WHITE,
+    ATTR_EFFECT,
+    ColorMode,
+    LightEntityFeature,
+    LightEntity,
+)
+
+from .const import DOMAIN
+from .coordinator import SP108ECoordinator
 from .pyledshop import WifiLedShopLight
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -9,11 +24,81 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up SP108E WS2815 light from a config entry."""
-    host = entry.data["host"]
-    name = entry.data["name"]
-    config = { **entry.data, **entry.options }
+    # Get coordinator and light from hass.data
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = data["coordinator"]
+    light = data["light"]
 
-    # Construct in executor to avoid blocking the event loop
-    light = await hass.async_add_executor_job(WifiLedShopLight, host, name, config)
+    # Create coordinator-based entity wrapper
+    async_add_entities([SP108ELight(coordinator, light)])
 
-    async_add_entities([light])
+
+class SP108ELight(CoordinatorEntity, LightEntity):
+    """Representation of SP108E WS2815 light with coordinator support."""
+
+    def __init__(self, coordinator: SP108ECoordinator, light: WifiLedShopLight) -> None:
+        """Initialize the light."""
+        super().__init__(coordinator)
+        self._light = light
+
+        # Copy attributes from the underlying light device
+        self._attr_name = light._attr_name
+        self._attr_unique_id = light._attr_unique_id
+        self._attr_supported_color_modes = light._attr_supported_color_modes
+        self._attr_color_mode = light._attr_color_mode
+        self._attr_supported_features = light._attr_supported_features
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self.coordinator.last_update_success
+
+    @property
+    def is_on(self):
+        """Return true if light is on."""
+        return self._light.is_on
+
+    @property
+    def brightness(self):
+        """Return the brightness of the light."""
+        return self._light.brightness
+
+    @property
+    def white_value(self):
+        """Return the white value of the light."""
+        return self._light.white_value
+
+    @property
+    def hs_color(self):
+        """Return the hue and saturation color value."""
+        return self._light.hs_color
+
+    @property
+    def effect_list(self):
+        """Return the list of supported effects."""
+        return self._light.effect_list
+
+    @property
+    def effect(self):
+        """Return the current effect."""
+        return self._light.effect
+
+    @property
+    def device_info(self):
+        """Return device information."""
+        return self._light.device_info
+
+    @property
+    def extra_state_attributes(self):
+        """Return extra state attributes."""
+        return self._light.extra_state_attributes
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the light on."""
+        await self.hass.async_add_executor_job(self._light.turn_on, **kwargs)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the light off."""
+        await self.hass.async_add_executor_job(self._light.turn_off, **kwargs)
+        await self.coordinator.async_request_refresh()

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "sp108e_ws2815",
   "name": "SP108E WS2815 LED Controller",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "config_flow": true,
   "documentation": "https://github.com/samhstein/sp108e_ws2815",
   "requirements": [],

--- a/pyledshop/WifiLedShopLight.py
+++ b/pyledshop/WifiLedShopLight.py
@@ -1,4 +1,5 @@
 import socket
+import logging
 from .effects import MONO_EFFECTS, PRESET_EFFECTS
 from .constants import Command, CommandFlag
 from .utils import clamp
@@ -15,6 +16,8 @@ from homeassistant.components.light import (
 )
 import homeassistant.util.color as color_util
 from time import sleep
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class WifiLedShopLight(LightEntity):
@@ -147,18 +150,36 @@ class WifiLedShopLight(LightEntity):
                 self._sock.close()
                 self._sock = None
                 return result
-            except (socket.timeout, BrokenPipeError):
+            except (socket.timeout, BrokenPipeError, ConnectionRefusedError, OSError) as e:
                 if attempts < self._retries:
                     attempts += 1
                     if self._sock:
-                        self._sock.close()
+                        try:
+                            self._sock.close()
+                        except:
+                            pass
+                        self._sock = None
                 else:
+                    if self._sock:
+                        try:
+                            self._sock.close()
+                        except:
+                            pass
+                        self._sock = None
                     raise
 
     def update(self):
-        response = self.send_command(Command.SYNC, [])
-        if response:
-            self._state.update_from_sync(bytearray(response))
+        """Update device state by syncing with the device."""
+        try:
+            response = self.send_command(Command.SYNC, [])
+            if response:
+                self._state.update_from_sync(bytearray(response))
+                _LOGGER.debug("Successfully updated device state for %s", self._ip)
+            else:
+                _LOGGER.warning("Empty response from device %s", self._ip)
+        except Exception as e:
+            _LOGGER.error("Failed to update device %s: %s", self._ip, str(e))
+            raise
 
     def __repr__(self):
         return f"""WifiLedShopLight @ {self._ip}:{self._port}


### PR DESCRIPTION
Implementa DataUpdateCoordinator para polling automático e detecção de dispositivos que voltam online sem necessidade de reiniciar o Home Assistant.

Principais melhorias:
- Novo DataUpdateCoordinator com polling a cada 30 segundos
- Rastreamento automático de disponibilidade do dispositivo
- Entidade wrapper SP108ELight usando CoordinatorEntity
- Melhor tratamento de erros de rede (ConnectionRefusedError, OSError)
- Logging aprimorado para diagnóstico de problemas
- Suporte a recarregamento automático quando opções mudam
- Atualização automática de estado sem bloqueio

Resolve o problema onde dispositivos não apareciam disponíveis até reiniciar o Home Assistant quando eram ligados.