### PR TITLE
Major Reliability Fixes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -18,6 +18,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up sp108e_ws2815 from a config entry."""
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = entry.data.get('host')
+    
+    # Store entities by entry_id for service access
+    if "entities" not in hass.data[DOMAIN]:
+        hass.data[DOMAIN]["entities"] = {}
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/config_flow.py
+++ b/config_flow.py
@@ -21,11 +21,20 @@ STEP_USER_DATA_SCHEMA = vol.Schema({
 async def validate_input(hass: core.HomeAssistant, data: dict) -> dict:
     """Validate the user input allows us to connect to the controller."""
     try:
-        light = await hass.async_add_executor_job(WifiLedShopLight, data["host"], data["name"])
+        config = {
+            "effect": data.get("effect", "Solid (custom color)"),
+            "speed": data.get("speed", 255),
+        }
+        light = await hass.async_add_executor_job(
+            WifiLedShopLight, data["host"], data["name"], config
+        )
         await hass.async_add_executor_job(light.update)
+    except ConnectionError as e:
+        _LOGGER.error("Failed to connect to SP108E controller at %s: %s", data["host"], str(e))
+        raise CannotConnect(str(e)) from e
     except Exception as e:
         _LOGGER.exception("Failed to connect to SP108E controller at %s", data["host"])
-        raise CannotConnect from e
+        raise CannotConnect(f"Connection failed: {str(e)}") from e
 
     return {
         "title": data["name"],
@@ -75,6 +84,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 class CannotConnect(exceptions.HomeAssistantError):
     """Error to indicate we cannot connect."""
+    
+    def __init__(self, message="Failed to connect to the device"):
+        super().__init__(message)
+        self.message = message
 
 
 class InvalidAuth(exceptions.HomeAssistantError):

--- a/light.py
+++ b/light.py
@@ -2,6 +2,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .pyledshop import WifiLedShopLight
+from .const import DOMAIN
+import logging
+
+_LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -17,3 +21,8 @@ async def async_setup_entry(
     light = await hass.async_add_executor_job(WifiLedShopLight, host, name, config)
 
     async_add_entities([light])
+    
+    # Store entity for service access
+    if "entities" not in hass.data[DOMAIN]:
+        hass.data[DOMAIN]["entities"] = {}
+    hass.data[DOMAIN]["entities"][entry.entry_id] = light

--- a/pyledshop/WifiLedShopLight.py
+++ b/pyledshop/WifiLedShopLight.py
@@ -221,14 +221,40 @@ class WifiLedShopLight(LightEntity):
                     ATTR_BRIGHTNESS_STEP_PCT,
                 )
             }
-            
+
             # If brightness is the only parameter, use debouncing (slider dragging)
             # Otherwise apply immediately (click or combined with other params)
             use_brightness_debounce = (
                 brightness_value is not None and len(other_params) == 0 and not was_off
             )
-            
-            # Process non-brightness parameters immediately (like effects)
+
+            # Decide which effect to apply:
+            # - If an explicit effect was provided, use it
+            # - Else, if an RGB/HS color was provided, force Solid (custom color)
+            # - Else, if we just turned the light on, use the configured default effect
+            has_rgb = "rgb_color" in other_params or ATTR_HS_COLOR in other_params
+            explicit_effect = other_params.pop(ATTR_EFFECT, None)
+
+            effect_to_apply = None
+            if explicit_effect is not None:
+                effect_to_apply = explicit_effect
+            elif has_rgb:
+                effect_to_apply = "Solid (custom color)"
+            elif was_off:
+                effect_to_apply = self._default_effect
+
+            if effect_to_apply is not None:
+                effect_brightness = (
+                    brightness_value
+                    if (brightness_value is not None and not use_brightness_debounce)
+                    else None
+                )
+                await self._hass.async_add_executor_job(
+                    self.set_effect, effect_to_apply, effect_brightness
+                )
+                self.async_write_ha_state()
+
+            # Process non-brightness, non-effect parameters immediately
             for k, v in other_params.items():
                 if k == "rgb_color":
                     await self._hass.async_add_executor_job(self.set_color, *v)
@@ -239,14 +265,6 @@ class WifiLedShopLight(LightEntity):
                     self.async_write_ha_state()
                 elif k == ATTR_WHITE:
                     await self._hass.async_add_executor_job(self.set_white, v)
-                    self.async_write_ha_state()
-                elif k == ATTR_EFFECT:
-                    # If brightness is also provided (and not debounced), set it with the effect
-                    effect_brightness = brightness_value if (brightness_value is not None and not use_brightness_debounce) else None
-                    if effect_brightness is not None:
-                        await self._hass.async_add_executor_job(self.set_effect, v, effect_brightness)
-                    else:
-                        await self._hass.async_add_executor_job(self.set_effect, v, None)
                     self.async_write_ha_state()
                 elif k == "speed":
                     await self._hass.async_add_executor_job(self.set_speed, v)

--- a/pyledshop/WifiLedShopLight.py
+++ b/pyledshop/WifiLedShopLight.py
@@ -268,6 +268,10 @@ class WifiLedShopLight(LightEntity):
                 await self._hass.async_add_executor_job(
                     self.set_effect, effect_to_apply, effect_brightness
                 )
+                # Give the controller a moment to apply the new effect before
+                # we start sending color/brightness updates. This mirrors the
+                # behavior of the mobile app, which spaces commands slightly.
+                await asyncio.sleep(0.1)
                 self.async_write_ha_state()
 
             # Process non-brightness, non-effect parameters immediately

--- a/pyledshop/WifiLedShopLight.py
+++ b/pyledshop/WifiLedShopLight.py
@@ -37,6 +37,8 @@ class WifiLedShopLight(LightEntity):
         self._update_lock = asyncio.Lock()
         self._brightness_task = None  # For debouncing brightness changes
         self._command_lock = asyncio.Lock()  # Prevent concurrent commands
+        self._desired_brightness = None  # Source of truth for brightness
+        self._desired_state = None  # Source of truth for on/off state
 
         self._attr_name = name
         self._attr_supported_color_modes = {ColorMode.RGB}
@@ -71,7 +73,9 @@ class WifiLedShopLight(LightEntity):
     def set_brightness(self, brightness=0):
         brightness = clamp(brightness)
         self.send_command(Command.SET_BRIGHTNESS, [brightness])
-        # Update state optimistically for immediate feedback (like effects)
+        # Set as source of truth - this is what we want
+        self._desired_brightness = brightness
+        # Update state optimistically for immediate feedback
         self._state.brightness = brightness
 
     def set_white(self, white=0):
@@ -104,11 +108,43 @@ class WifiLedShopLight(LightEntity):
         self._state.mode = custom
         self.send_command(Command.SET_CUSTOM, [custom])
 
-    def _toggle_sync(self):
-        """Toggle the light state (synchronous)."""
-        self.send_command(Command.TOGGLE, [])
-        # Update state optimistically for immediate feedback (like effects)
-        self._state.is_on = not self._state.is_on
+    def _toggle_sync(self, desired_state=None):
+        """Toggle the light state (synchronous).
+        
+        Args:
+            desired_state: If provided, toggle until this state is reached.
+                          None means just toggle once.
+        """
+        if desired_state is not None:
+            # Toggle until we reach desired state
+            max_attempts = 3
+            for attempt in range(max_attempts):
+                self.send_command(Command.TOGGLE, [])
+                # Small delay to let device process
+                sleep(0.1)
+                # Check if we need to toggle again
+                if attempt < max_attempts - 1:
+                    # Sync to check actual state
+                    try:
+                        response = self.send_command(Command.SYNC, [])
+                        if response:
+                            actual_state = bytearray(response)[1]  # IS_ON position
+                            if bool(actual_state) == desired_state:
+                                break
+                    except:
+                        pass
+        else:
+            # Just toggle once
+            self.send_command(Command.TOGGLE, [])
+        
+        # Update desired state as source of truth
+        if desired_state is not None:
+            self._desired_state = desired_state
+            self._state.is_on = desired_state
+        else:
+            # Toggle desired state
+            self._desired_state = not self._state.is_on if self._desired_state is None else not self._desired_state
+            self._state.is_on = self._desired_state
 
     async def _sync_state(self):
         """Force sync state from device."""
@@ -120,8 +156,13 @@ class WifiLedShopLight(LightEntity):
             return
         
         async with self._command_lock:
-            # Check current state (optimistic, like effects do)
+            # Sync actual state first to know real device state
+            await self._sync_state()
+            
+            # Check current state
             was_off = not self._state.is_on
+            # Set desired state as source of truth
+            self._desired_state = True
             
             # If turning on from off, apply defaults first
             if was_off:
@@ -200,9 +241,13 @@ class WifiLedShopLight(LightEntity):
                     await self._hass.async_add_executor_job(self.set_brightness, brightness_value)
                     self.async_write_ha_state()
 
-            # Turn on if it was off
+            # Turn on if it was off - use toggle with desired state
             if was_off:
-                await self._hass.async_add_executor_job(self._toggle_sync)
+                await self._hass.async_add_executor_job(self._toggle_sync, True)
+                self.async_write_ha_state()
+            else:
+                # Already on, but update state to reflect desired state
+                self._state.is_on = True
                 self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
@@ -211,9 +256,19 @@ class WifiLedShopLight(LightEntity):
             return
         
         async with self._command_lock:
-            # Check state optimistically (like effects)
+            # Always sync actual state first to know real device state
+            await self._sync_state()
+            
+            # Set desired state as source of truth
+            self._desired_state = False
+            
+            # Turn off if it's on - use toggle with desired state
             if self._state.is_on:
-                await self._hass.async_add_executor_job(self._toggle_sync)
+                await self._hass.async_add_executor_job(self._toggle_sync, False)
+                self.async_write_ha_state()
+            else:
+                # Already off, but update state to reflect desired state
+                self._state.is_on = False
                 self.async_write_ha_state()
 
     def set_segments(self, segments):
@@ -299,7 +354,16 @@ class WifiLedShopLight(LightEntity):
                     self.send_command, Command.SYNC, []
                 )
                 if response:
+                    old_state = self._state.is_on
                     self._state.update_from_sync(bytearray(response))
+                    
+                    # If we have a desired state, use it as source of truth for on/off
+                    if self._desired_state is not None:
+                        self._state.is_on = self._desired_state
+                    
+                    # If we have a desired brightness, use it as source of truth
+                    if self._desired_brightness is not None:
+                        self._state.brightness = self._desired_brightness
             except Exception as e:
                 _LOGGER.warning("Failed to update state: %s", e)
 

--- a/pyledshop/WifiLedShopLight.py
+++ b/pyledshop/WifiLedShopLight.py
@@ -1,4 +1,5 @@
 import socket
+import logging
 from .effects import MONO_EFFECTS, PRESET_EFFECTS
 from .constants import Command, CommandFlag
 from .utils import clamp
@@ -16,11 +17,13 @@ from homeassistant.components.light import (
 import homeassistant.util.color as color_util
 from time import sleep
 
+_LOGGER = logging.getLogger(__name__)
+
 
 class WifiLedShopLight(LightEntity):
     """A Wifi LED Shop Light."""
 
-    def __init__(self, ip, name, config, port=8189, timeout=1, retries=5):
+    def __init__(self, ip, name, config, port=8189, timeout=3, retries=5):
         self._ip = ip
         self._default_effect = config.get("effect", "Solid (custom color)")
         self._default_speed = config.get("speed", 255)
@@ -31,12 +34,28 @@ class WifiLedShopLight(LightEntity):
         self._sock = None
 
         self._attr_name = name
-        self._attr_unique_id = self.send_command(Command.GET_ID, []).decode("utf-8")
         self._attr_supported_color_modes = {ColorMode.RGB}
         self._attr_color_mode = ColorMode.RGB
         self._attr_supported_features = LightEntityFeature.EFFECT
 
-        self.update()
+        # Try to get unique_id, but fall back to IP-based ID if connection fails
+        try:
+            id_response = self.send_command(Command.GET_ID, [])
+            if id_response:
+                self._attr_unique_id = id_response.decode("utf-8")
+            else:
+                self._attr_unique_id = f"sp108e_{ip}_{port}"
+        except Exception:
+            # If we can't get the ID, use a fallback based on IP and port
+            self._attr_unique_id = f"sp108e_{ip}_{port}"
+
+        # Try to update state, but don't fail initialization if it doesn't work
+        try:
+            self.update()
+        except Exception:
+            # Initial update failed, but we can still create the entity
+            # It will be updated later when HA polls it
+            pass
 
     def __enter__(self):
         return self
@@ -135,25 +154,55 @@ class WifiLedShopLight(LightEntity):
         padded_data = data + [0] * (min_data_len - len(data))
         raw_data = [CommandFlag.START, *padded_data, command, CommandFlag.END]
         attempts = 0
-        while True:
+        last_exception = None
+        
+        while attempts <= self._retries:
             try:
+                _LOGGER.debug("Attempting to connect to %s:%s (attempt %d/%d)", 
+                             self._ip, self._port, attempts + 1, self._retries + 1)
                 self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 self._sock.settimeout(self._timeout)
                 self._sock.connect((self._ip, self._port))
+                _LOGGER.debug("Connected to %s:%s, sending command %s", 
+                             self._ip, self._port, command)
                 self._sock.sendall(bytes(raw_data))
                 if command in [Command.GET_ID, Command.SYNC]:
                     result = self._sock.recv(1024)
+                    _LOGGER.debug("Received %d bytes from device", len(result) if result else 0)
                 self._sock.shutdown(socket.SHUT_RDWR)
                 self._sock.close()
                 self._sock = None
                 return result
-            except (socket.timeout, BrokenPipeError):
+            except (socket.timeout, BrokenPipeError, ConnectionRefusedError, 
+                    ConnectionResetError, OSError, socket.gaierror, socket.herror) as e:
+                last_exception = e
+                _LOGGER.warning("Connection attempt %d/%d failed: %s", 
+                               attempts + 1, self._retries + 1, str(e))
+                if self._sock:
+                    try:
+                        self._sock.close()
+                    except:
+                        pass
+                    self._sock = None
+                
                 if attempts < self._retries:
                     attempts += 1
-                    if self._sock:
-                        self._sock.close()
+                    sleep(0.1 * attempts)  # Exponential backoff
                 else:
-                    raise
+                    # Raise a more informative error
+                    error_msg = f"Failed to connect to {self._ip}:{self._port} after {self._retries + 1} attempts. "
+                    if isinstance(e, ConnectionRefusedError):
+                        error_msg += f"Connection refused - check if device is powered on and port {self._port} is open."
+                    elif isinstance(e, socket.timeout):
+                        error_msg += "Connection timeout - check network connectivity and firewall settings."
+                    elif isinstance(e, (socket.gaierror, socket.herror)):
+                        error_msg += f"DNS/Host resolution error: {str(e)} - verify the IP address is correct."
+                    elif isinstance(e, OSError):
+                        error_msg += f"Network error: {str(e)}"
+                    else:
+                        error_msg += f"Error: {str(e)}"
+                    _LOGGER.error(error_msg)
+                    raise ConnectionError(error_msg) from e
 
     def update(self):
         response = self.send_command(Command.SYNC, [])

--- a/pyledshop/WifiLedShopLight.py
+++ b/pyledshop/WifiLedShopLight.py
@@ -39,6 +39,8 @@ class WifiLedShopLight(LightEntity):
         self._command_lock = asyncio.Lock()  # Prevent concurrent commands
         self._desired_brightness = None  # Source of truth for brightness
         self._desired_state = None  # Source of truth for on/off state
+        self._desired_color = None  # Source of truth for color
+        self._desired_effect = None  # Source of truth for effect
 
         self._attr_name = name
         self._attr_supported_color_modes = {ColorMode.RGB}
@@ -67,7 +69,9 @@ class WifiLedShopLight(LightEntity):
     def set_color(self, r=0, g=0, b=0):
         r, g, b = clamp(r), clamp(g), clamp(b)
         self.send_command(Command.SET_COLOR, [r, g, b])
-        # Update state optimistically for immediate feedback (like effects)
+        # Set as source of truth - this is what we want
+        self._desired_color = (r, g, b)
+        # Update state optimistically for immediate feedback
         self._state.color = (r, g, b)
 
     def set_brightness(self, brightness=0):
@@ -97,6 +101,8 @@ class WifiLedShopLight(LightEntity):
         # Don't clamp preset values - they can be 0-212
         # MonoEffect values are 205-212, PRESET_EFFECTS are 0-195
         self.send_command(Command.SET_PRESET, [preset])
+        # Set as source of truth - this is what we want
+        self._desired_effect = effect
         # Update state optimistically for immediate feedback
         self._state.mode = preset
         # If brightness is provided with effect, set it too
@@ -156,16 +162,19 @@ class WifiLedShopLight(LightEntity):
             return
         
         async with self._command_lock:
-            # Sync actual state first to know real device state
-            await self._sync_state()
+            # Check current state (use desired state if available, otherwise sync)
+            if self._desired_state is None:
+                await self._sync_state()
+            was_off = not (self._desired_state if self._desired_state is not None else self._state.is_on)
             
-            # Check current state
-            was_off = not self._state.is_on
             # Set desired state as source of truth
             self._desired_state = True
             
-            # If turning on from off, apply defaults first
+            # Turn on first if it was off (needed for colors/effects to work)
             if was_off:
+                await self._hass.async_add_executor_job(self._toggle_sync, True)
+                self.async_write_ha_state()
+                # Apply defaults after turning on
                 if ATTR_EFFECT not in kwargs:
                     await self._hass.async_add_executor_job(
                         self.set_effect, self._default_effect
@@ -241,12 +250,8 @@ class WifiLedShopLight(LightEntity):
                     await self._hass.async_add_executor_job(self.set_brightness, brightness_value)
                     self.async_write_ha_state()
 
-            # Turn on if it was off - use toggle with desired state
-            if was_off:
-                await self._hass.async_add_executor_job(self._toggle_sync, True)
-                self.async_write_ha_state()
-            else:
-                # Already on, but update state to reflect desired state
+            # Update state to reflect desired state if already on
+            if not was_off:
                 self._state.is_on = True
                 self.async_write_ha_state()
 
@@ -256,14 +261,16 @@ class WifiLedShopLight(LightEntity):
             return
         
         async with self._command_lock:
-            # Always sync actual state first to know real device state
-            await self._sync_state()
+            # Check current state (use desired state if available, otherwise sync)
+            if self._desired_state is None:
+                await self._sync_state()
+            is_on = self._desired_state if self._desired_state is not None else self._state.is_on
             
             # Set desired state as source of truth
             self._desired_state = False
             
             # Turn off if it's on - use toggle with desired state
-            if self._state.is_on:
+            if is_on:
                 await self._hass.async_add_executor_job(self._toggle_sync, False)
                 self.async_write_ha_state()
             else:
@@ -354,16 +361,24 @@ class WifiLedShopLight(LightEntity):
                     self.send_command, Command.SYNC, []
                 )
                 if response:
-                    old_state = self._state.is_on
+                    # Update state from device
                     self._state.update_from_sync(bytearray(response))
                     
-                    # If we have a desired state, use it as source of truth for on/off
+                    # Use desired values as source of truth (don't let sync override)
                     if self._desired_state is not None:
                         self._state.is_on = self._desired_state
                     
-                    # If we have a desired brightness, use it as source of truth
                     if self._desired_brightness is not None:
                         self._state.brightness = self._desired_brightness
+                    
+                    if self._desired_color is not None:
+                        self._state.color = self._desired_color
+                    
+                    if self._desired_effect is not None:
+                        # Update mode from desired effect
+                        both = {**MONO_EFFECTS, **PRESET_EFFECTS}
+                        if self._desired_effect in both:
+                            self._state.mode = both[self._desired_effect]
             except Exception as e:
                 _LOGGER.warning("Failed to update state: %s", e)
 

--- a/pyledshop/WifiLedShopLight.py
+++ b/pyledshop/WifiLedShopLight.py
@@ -265,13 +265,26 @@ class WifiLedShopLight(LightEntity):
                     if (brightness_value is not None and not use_brightness_debounce)
                     else None
                 )
-                await self._hass.async_add_executor_job(
-                    self.set_effect, effect_to_apply, effect_brightness
-                )
-                # Give the controller a moment to apply the new effect before
-                # we start sending color/brightness updates. This mirrors the
-                # behavior of the mobile app, which spaces commands slightly.
-                await asyncio.sleep(0.1)
+                # If we are turning the light on from OFF and the caller is only
+                # changing the preset (no rgb/hs color), the controller is prone
+                # to ignore a single preset command. In that specific case we
+                # apply the effect twice with a short delay, mimicking two user
+                # presses in the mobile app. For all other cases we apply it
+                # once as usual.
+                if (not is_on) and (explicit_effect is not None) and (not has_rgb):
+                    for _ in range(2):
+                        await self._hass.async_add_executor_job(
+                            self.set_effect, effect_to_apply, effect_brightness
+                        )
+                        await asyncio.sleep(0.12)
+                else:
+                    await self._hass.async_add_executor_job(
+                        self.set_effect, effect_to_apply, effect_brightness
+                        )
+                    # Give the controller a moment to apply the new effect before
+                    # we start sending color/brightness updates. This mirrors the
+                    # behavior of the mobile app, which spaces commands slightly.
+                    await asyncio.sleep(0.1)
                 self.async_write_ha_state()
 
             # Process non-brightness, non-effect parameters immediately

--- a/pyledshop/WifiLedShopLight.py
+++ b/pyledshop/WifiLedShopLight.py
@@ -71,11 +71,33 @@ class WifiLedShopLight(LightEntity):
 
     def set_color(self, r=0, g=0, b=0):
         r, g, b = clamp(r), clamp(g), clamp(b)
+        target = (r, g, b)
+
+        # Send the color command once
         self.send_command(Command.SET_COLOR, [r, g, b])
-        # Set as source of truth - this is what we want
-        self._desired_color = (r, g, b)
-        # Update state optimistically for immediate feedback
-        self._state.color = (r, g, b)
+        self._desired_color = target
+        self._state.color = target
+
+        # Best-effort verification: read back state once and, if the color
+        # does not match what we requested, resend the command a second time.
+        try:
+            response = self.send_command(Command.SYNC, [])
+            if response:
+                verify_state = WifiLedShopLightState()
+                verify_state.update_from_sync(bytearray(response))
+                if verify_state.color != target:
+                    _LOGGER.debug(
+                        "Color verification mismatch (got %s, expected %s); resending",
+                        verify_state.color,
+                        target,
+                    )
+                    self.send_command(Command.SET_COLOR, [r, g, b])
+                    self._desired_color = target
+                    self._state.color = target
+        except Exception as e:
+            # If verification fails (timeout, etc.), don't break the flow –
+            # we already sent the color command once.
+            _LOGGER.debug("Color verification failed: %s", e)
 
     def set_brightness(self, brightness=0):
         brightness = clamp(brightness)
@@ -168,24 +190,12 @@ class WifiLedShopLight(LightEntity):
             # Check current state (use desired state if available, otherwise sync)
             if self._desired_state is None:
                 await self._sync_state()
-            was_off = not (self._desired_state if self._desired_state is not None else self._state.is_on)
+            was_off = not (
+                self._desired_state if self._desired_state is not None else self._state.is_on
+            )
             
             # Set desired state as source of truth
             self._desired_state = True
-            
-            # Turn on first if it was off (needed for colors/effects to work)
-            if was_off:
-                await self._hass.async_add_executor_job(self._toggle_sync, True)
-                self.async_write_ha_state()
-                # Apply defaults after turning on
-                if ATTR_EFFECT not in kwargs:
-                    await self._hass.async_add_executor_job(
-                        self.set_effect, self._default_effect
-                    )
-                if "speed" not in kwargs:
-                    await self._hass.async_add_executor_job(
-                        self.set_speed, self._default_speed
-                    )
             
             # Process all provided parameters
             # Handle brightness separately (including *_pct and *_step variants)
@@ -272,6 +282,14 @@ class WifiLedShopLight(LightEntity):
                 else:
                     _LOGGER.debug("Unknown control key: %s", k)
             
+            # If we turned the light on from off and no explicit speed was provided,
+            # apply the configured default speed.
+            if was_off and "speed" not in kwargs:
+                await self._hass.async_add_executor_job(
+                    self.set_speed, self._default_speed
+                )
+                self.async_write_ha_state()
+
             # Handle brightness
             if brightness_value is not None:
                 if use_brightness_debounce:
@@ -302,9 +320,15 @@ class WifiLedShopLight(LightEntity):
                     # Apply immediately (click or combined with other params)
                     await self._hass.async_add_executor_job(self.set_brightness, brightness_value)
                     self.async_write_ha_state()
-
-            # Update state to reflect desired state if already on
-            if not was_off:
+            
+            # Finally, if the light was off when we started, toggle it on *after*
+            # effect/color/speed/brightness have been applied so the new state
+            # is what shows when the strip turns on.
+            if was_off:
+                await self._hass.async_add_executor_job(self._toggle_sync, True)
+                self.async_write_ha_state()
+            else:
+                # Already on, just ensure state matches desired on-state
                 self._state.is_on = True
                 self.async_write_ha_state()
 

--- a/pyledshop/WifiLedShopLight.py
+++ b/pyledshop/WifiLedShopLight.py
@@ -9,6 +9,9 @@ from .WifiLedShopLightState import WifiLedShopLightState
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
+    ATTR_BRIGHTNESS_PCT,
+    ATTR_BRIGHTNESS_STEP,
+    ATTR_BRIGHTNESS_STEP_PCT,
     ATTR_HS_COLOR,
     ATTR_WHITE,
     ATTR_EFFECT,
@@ -185,13 +188,45 @@ class WifiLedShopLight(LightEntity):
                     )
             
             # Process all provided parameters
-            # Handle brightness separately for debouncing (only when it's the only parameter)
-            brightness_value = kwargs.get(ATTR_BRIGHTNESS)
-            other_params = {k: v for k, v in kwargs.items() if k != ATTR_BRIGHTNESS}
+            # Handle brightness separately (including *_pct and *_step variants)
+            current_brightness = (
+                self._desired_brightness
+                if self._desired_brightness is not None
+                else self._state.brightness
+            )
+
+            brightness_value = None
+            if ATTR_BRIGHTNESS in kwargs and kwargs[ATTR_BRIGHTNESS] is not None:
+                brightness_value = kwargs[ATTR_BRIGHTNESS]
+            elif ATTR_BRIGHTNESS_PCT in kwargs and kwargs[ATTR_BRIGHTNESS_PCT] is not None:
+                brightness_value = int(255 * kwargs[ATTR_BRIGHTNESS_PCT] / 100)
+            elif ATTR_BRIGHTNESS_STEP in kwargs and kwargs[ATTR_BRIGHTNESS_STEP] is not None:
+                brightness_value = clamp(current_brightness + kwargs[ATTR_BRIGHTNESS_STEP])
+            elif (
+                ATTR_BRIGHTNESS_STEP_PCT in kwargs
+                and kwargs[ATTR_BRIGHTNESS_STEP_PCT] is not None
+            ):
+                delta = int(255 * kwargs[ATTR_BRIGHTNESS_STEP_PCT] / 100)
+                brightness_value = clamp(current_brightness + delta)
+
+            # Remove all brightness-related keys from other params
+            other_params = {
+                k: v
+                for k, v in kwargs.items()
+                if k
+                not in (
+                    ATTR_BRIGHTNESS,
+                    ATTR_BRIGHTNESS_PCT,
+                    ATTR_BRIGHTNESS_STEP,
+                    ATTR_BRIGHTNESS_STEP_PCT,
+                )
+            }
             
             # If brightness is the only parameter, use debouncing (slider dragging)
             # Otherwise apply immediately (click or combined with other params)
-            use_brightness_debounce = brightness_value is not None and len(other_params) == 0 and not was_off
+            use_brightness_debounce = (
+                brightness_value is not None and len(other_params) == 0 and not was_off
+            )
             
             # Process non-brightness parameters immediately (like effects)
             for k, v in other_params.items():

--- a/pyledshop/WifiLedShopLight.py
+++ b/pyledshop/WifiLedShopLight.py
@@ -185,20 +185,26 @@ class WifiLedShopLight(LightEntity):
         """Turn on the light with optional parameters (async)."""
         if self._hass is None:
             return
-        
+
         async with self._command_lock:
-            # Check current state (use desired state if available, otherwise sync)
+            # 1) Determine current on/off state from device/desired state
             if self._desired_state is None:
                 await self._sync_state()
-            was_off = not (
-                self._desired_state if self._desired_state is not None else self._state.is_on
+            is_on = (
+                self._desired_state
+                if self._desired_state is not None
+                else self._state.is_on
             )
-            
-            # Set desired state as source of truth
-            self._desired_state = True
-            
-            # Process all provided parameters
-            # Handle brightness separately (including *_pct and *_step variants)
+
+            # 2) If off, turn on first so subsequent commands are applied while on
+            if not is_on:
+                await self._hass.async_add_executor_job(self._toggle_sync, True)
+                self._desired_state = True
+                self._state.is_on = True
+                self.async_write_ha_state()
+
+            # 3) Process all provided parameters
+            #    Handle brightness separately (including *_pct and *_step variants)
             current_brightness = (
                 self._desired_brightness
                 if self._desired_brightness is not None
@@ -235,7 +241,7 @@ class WifiLedShopLight(LightEntity):
             # If brightness is the only parameter, use debouncing (slider dragging)
             # Otherwise apply immediately (click or combined with other params)
             use_brightness_debounce = (
-                brightness_value is not None and len(other_params) == 0 and not was_off
+                brightness_value is not None and len(other_params) == 0 and self._state.is_on
             )
 
             # Decide which effect to apply:
@@ -250,7 +256,7 @@ class WifiLedShopLight(LightEntity):
                 effect_to_apply = explicit_effect
             elif has_rgb:
                 effect_to_apply = "Solid (custom color)"
-            elif was_off:
+            elif not is_on:
                 effect_to_apply = self._default_effect
 
             if effect_to_apply is not None:
@@ -281,14 +287,6 @@ class WifiLedShopLight(LightEntity):
                     self.async_write_ha_state()
                 else:
                     _LOGGER.debug("Unknown control key: %s", k)
-            
-            # If we turned the light on from off and no explicit speed was provided,
-            # apply the configured default speed.
-            if was_off and "speed" not in kwargs:
-                await self._hass.async_add_executor_job(
-                    self.set_speed, self._default_speed
-                )
-                self.async_write_ha_state()
 
             # Handle brightness
             if brightness_value is not None:
@@ -320,17 +318,11 @@ class WifiLedShopLight(LightEntity):
                     # Apply immediately (click or combined with other params)
                     await self._hass.async_add_executor_job(self.set_brightness, brightness_value)
                     self.async_write_ha_state()
-            
-            # Finally, if the light was off when we started, toggle it on *after*
-            # effect/color/speed/brightness have been applied so the new state
-            # is what shows when the strip turns on.
-            if was_off:
-                await self._hass.async_add_executor_job(self._toggle_sync, True)
-                self.async_write_ha_state()
-            else:
-                # Already on, just ensure state matches desired on-state
-                self._state.is_on = True
-                self.async_write_ha_state()
+
+            # Ensure internal state reflects on
+            self._desired_state = True
+            self._state.is_on = True
+            self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn off the light (async)."""

--- a/pyledshop/WifiLedShopLight.py
+++ b/pyledshop/WifiLedShopLight.py
@@ -65,12 +65,14 @@ class WifiLedShopLight(LightEntity):
     def set_color(self, r=0, g=0, b=0):
         r, g, b = clamp(r), clamp(g), clamp(b)
         self.send_command(Command.SET_COLOR, [r, g, b])
-        # Don't update state optimistically - let sync handle it
+        # Update state optimistically for immediate feedback (like effects)
+        self._state.color = (r, g, b)
 
     def set_brightness(self, brightness=0):
         brightness = clamp(brightness)
         self.send_command(Command.SET_BRIGHTNESS, [brightness])
-        # Don't update state optimistically - let sync handle it
+        # Update state optimistically for immediate feedback (like effects)
+        self._state.brightness = brightness
 
     def set_white(self, white=0):
         white = clamp(white)
@@ -82,7 +84,7 @@ class WifiLedShopLight(LightEntity):
         self.send_command(Command.SET_SPEED, [speed])
         # Don't update state optimistically - let sync handle it
 
-    def set_effect(self, effect):
+    def set_effect(self, effect, brightness=None):
         both = {**MONO_EFFECTS, **PRESET_EFFECTS}
         if effect not in both:
             _LOGGER.warning("Unknown effect: %s", effect)
@@ -91,7 +93,11 @@ class WifiLedShopLight(LightEntity):
         # Don't clamp preset values - they can be 0-212
         # MonoEffect values are 205-212, PRESET_EFFECTS are 0-195
         self.send_command(Command.SET_PRESET, [preset])
-        # Don't update state optimistically - let sync handle it
+        # Update state optimistically for immediate feedback
+        self._state.mode = preset
+        # If brightness is provided with effect, set it too
+        if brightness is not None:
+            self.set_brightness(brightness)
 
     def set_custom(self, custom):
         custom = clamp(custom, 1, 12)
@@ -101,7 +107,8 @@ class WifiLedShopLight(LightEntity):
     def _toggle_sync(self):
         """Toggle the light state (synchronous)."""
         self.send_command(Command.TOGGLE, [])
-        # Don't update state optimistically - always verify with sync
+        # Update state optimistically for immediate feedback (like effects)
+        self._state.is_on = not self._state.is_on
 
     async def _sync_state(self):
         """Force sync state from device."""
@@ -113,11 +120,7 @@ class WifiLedShopLight(LightEntity):
             return
         
         async with self._command_lock:
-            # Always sync state first to know actual device state
-            await self._sync_state()
-            
-            # Only apply defaults if turning on from off state
-            # If already on and just changing color/effect, don't override
+            # Check current state (optimistic, like effects do)
             was_off = not self._state.is_on
             
             # If turning on from off, apply defaults first
@@ -140,19 +143,29 @@ class WifiLedShopLight(LightEntity):
             # Otherwise apply immediately (click or combined with other params)
             use_brightness_debounce = brightness_value is not None and len(other_params) == 0 and not was_off
             
-            # Process non-brightness parameters immediately
+            # Process non-brightness parameters immediately (like effects)
             for k, v in other_params.items():
                 if k == "rgb_color":
                     await self._hass.async_add_executor_job(self.set_color, *v)
+                    self.async_write_ha_state()
                 elif k == ATTR_HS_COLOR:
                     r, g, b = color_util.color_hs_to_RGB(*v)
                     await self._hass.async_add_executor_job(self.set_color, r, g, b)
+                    self.async_write_ha_state()
                 elif k == ATTR_WHITE:
                     await self._hass.async_add_executor_job(self.set_white, v)
+                    self.async_write_ha_state()
                 elif k == ATTR_EFFECT:
-                    await self._hass.async_add_executor_job(self.set_effect, v)
+                    # If brightness is also provided (and not debounced), set it with the effect
+                    effect_brightness = brightness_value if (brightness_value is not None and not use_brightness_debounce) else None
+                    if effect_brightness is not None:
+                        await self._hass.async_add_executor_job(self.set_effect, v, effect_brightness)
+                    else:
+                        await self._hass.async_add_executor_job(self.set_effect, v, None)
+                    self.async_write_ha_state()
                 elif k == "speed":
                     await self._hass.async_add_executor_job(self.set_speed, v)
+                    self.async_write_ha_state()
                 else:
                     _LOGGER.debug("Unknown control key: %s", k)
             
@@ -176,7 +189,8 @@ class WifiLedShopLight(LightEntity):
                         try:
                             await asyncio.sleep(0.2)  # 200ms debounce
                             await self._hass.async_add_executor_job(self.set_brightness, brightness_value)
-                            await self._sync_state()
+                            # Update UI after debounced command
+                            self.async_write_ha_state()
                         except asyncio.CancelledError:
                             pass
                     
@@ -184,13 +198,12 @@ class WifiLedShopLight(LightEntity):
                 else:
                     # Apply immediately (click or combined with other params)
                     await self._hass.async_add_executor_job(self.set_brightness, brightness_value)
+                    self.async_write_ha_state()
 
             # Turn on if it was off
             if was_off:
                 await self._hass.async_add_executor_job(self._toggle_sync)
-            
-            # Always sync state after operations to get actual device state
-            await self._sync_state()
+                self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn off the light (async)."""
@@ -198,23 +211,10 @@ class WifiLedShopLight(LightEntity):
             return
         
         async with self._command_lock:
-            # Always sync state first to know actual device state
-            await self._sync_state()
-            
+            # Check state optimistically (like effects)
             if self._state.is_on:
                 await self._hass.async_add_executor_job(self._toggle_sync)
-                # Always sync state after toggle to verify it worked
-                await self._sync_state()
-                
-                # If still on after toggle, try again (device might be slow)
-                if self._state.is_on:
-                    await asyncio.sleep(0.2)
-                    await self._sync_state()
-                    if self._state.is_on:
-                        _LOGGER.warning("Device did not turn off after toggle, trying again")
-                        await self._hass.async_add_executor_job(self._toggle_sync)
-                        await asyncio.sleep(0.2)
-                        await self._sync_state()
+                self.async_write_ha_state()
 
     def set_segments(self, segments):
         self.send_command(Command.SET_SEGMENT_COUNT, [segments])
@@ -353,10 +353,14 @@ class WifiLedShopLight(LightEntity):
     @property
     def extra_state_attributes(self):
         r, g, b = self._state.color
+        both = {**MONO_EFFECTS, **PRESET_EFFECTS}
+        current_effect = next((k for k, v in both.items() if v == self._state.mode), None)
         return {
             "brightness": self._state.brightness,
+            "effect": current_effect,
             "speed": self._state.speed,
             "default_effect": self._default_effect,
             "current_rgb": f"rgb({r}, {g}, {b})",
             "white_value": self._state.white
         }
+

--- a/pyledshop/WifiLedShopLight.py
+++ b/pyledshop/WifiLedShopLight.py
@@ -35,6 +35,8 @@ class WifiLedShopLight(LightEntity):
         self._sock = None
         self._hass = None  # Will be set by async_added_to_hass
         self._update_lock = asyncio.Lock()
+        self._brightness_task = None  # For debouncing brightness changes
+        self._command_lock = asyncio.Lock()  # Prevent concurrent commands
 
         self._attr_name = name
         self._attr_supported_color_modes = {ColorMode.RGB}
@@ -63,23 +65,22 @@ class WifiLedShopLight(LightEntity):
     def set_color(self, r=0, g=0, b=0):
         r, g, b = clamp(r), clamp(g), clamp(b)
         self.send_command(Command.SET_COLOR, [r, g, b])
-        # Update state after successful command
-        self._state.color = (r, g, b)
+        # Don't update state optimistically - let sync handle it
 
     def set_brightness(self, brightness=0):
         brightness = clamp(brightness)
         self.send_command(Command.SET_BRIGHTNESS, [brightness])
-        self._state.brightness = brightness
+        # Don't update state optimistically - let sync handle it
 
     def set_white(self, white=0):
         white = clamp(white)
         self.send_command(Command.SET_WHITE, [white])
-        self._state.white = white
+        # Don't update state optimistically - let sync handle it
 
     def set_speed(self, speed=0):
         speed = clamp(speed)
         self.send_command(Command.SET_SPEED, [speed])
-        self._state.speed = speed
+        # Don't update state optimistically - let sync handle it
 
     def set_effect(self, effect):
         both = {**MONO_EFFECTS, **PRESET_EFFECTS}
@@ -90,7 +91,7 @@ class WifiLedShopLight(LightEntity):
         # Don't clamp preset values - they can be 0-212
         # MonoEffect values are 205-212, PRESET_EFFECTS are 0-195
         self.send_command(Command.SET_PRESET, [preset])
-        self._state.mode = preset
+        # Don't update state optimistically - let sync handle it
 
     def set_custom(self, custom):
         custom = clamp(custom, 1, 12)
@@ -100,62 +101,120 @@ class WifiLedShopLight(LightEntity):
     def _toggle_sync(self):
         """Toggle the light state (synchronous)."""
         self.send_command(Command.TOGGLE, [])
-        # Invert state optimistically - will be corrected by next update
-        self._state.is_on = not self._state.is_on
+        # Don't update state optimistically - always verify with sync
+
+    async def _sync_state(self):
+        """Force sync state from device."""
+        await self.async_update()
 
     async def async_turn_on(self, **kwargs):
         """Turn on the light with optional parameters (async)."""
         if self._hass is None:
             return
         
-        # Only apply defaults if turning on from off state
-        # If already on and just changing color/effect, don't override
-        was_off = not self._state.is_on
-        
-        # If turning on from off, apply defaults first
-        if was_off:
-            if ATTR_EFFECT not in kwargs:
-                await self._hass.async_add_executor_job(
-                    self.set_effect, self._default_effect
-                )
-            if "speed" not in kwargs:
-                await self._hass.async_add_executor_job(
-                    self.set_speed, self._default_speed
-                )
-        
-        # Process all provided parameters
-        for k, v in kwargs.items():
-            if k == ATTR_BRIGHTNESS:
-                await self._hass.async_add_executor_job(self.set_brightness, v)
-            elif k == "rgb_color":
-                await self._hass.async_add_executor_job(self.set_color, *v)
-            elif k == ATTR_HS_COLOR:
-                r, g, b = color_util.color_hs_to_RGB(*v)
-                await self._hass.async_add_executor_job(self.set_color, r, g, b)
-            elif k == ATTR_WHITE:
-                await self._hass.async_add_executor_job(self.set_white, v)
-            elif k == ATTR_EFFECT:
-                await self._hass.async_add_executor_job(self.set_effect, v)
-            elif k == "speed":
-                await self._hass.async_add_executor_job(self.set_speed, v)
-            else:
-                _LOGGER.debug("Unknown control key: %s", k)
+        async with self._command_lock:
+            # Always sync state first to know actual device state
+            await self._sync_state()
+            
+            # Only apply defaults if turning on from off state
+            # If already on and just changing color/effect, don't override
+            was_off = not self._state.is_on
+            
+            # If turning on from off, apply defaults first
+            if was_off:
+                if ATTR_EFFECT not in kwargs:
+                    await self._hass.async_add_executor_job(
+                        self.set_effect, self._default_effect
+                    )
+                if "speed" not in kwargs:
+                    await self._hass.async_add_executor_job(
+                        self.set_speed, self._default_speed
+                    )
+            
+            # Process all provided parameters
+            # Handle brightness separately for debouncing (only when it's the only parameter)
+            brightness_value = kwargs.get(ATTR_BRIGHTNESS)
+            other_params = {k: v for k, v in kwargs.items() if k != ATTR_BRIGHTNESS}
+            
+            # If brightness is the only parameter, use debouncing (slider dragging)
+            # Otherwise apply immediately (click or combined with other params)
+            use_brightness_debounce = brightness_value is not None and len(other_params) == 0 and not was_off
+            
+            # Process non-brightness parameters immediately
+            for k, v in other_params.items():
+                if k == "rgb_color":
+                    await self._hass.async_add_executor_job(self.set_color, *v)
+                elif k == ATTR_HS_COLOR:
+                    r, g, b = color_util.color_hs_to_RGB(*v)
+                    await self._hass.async_add_executor_job(self.set_color, r, g, b)
+                elif k == ATTR_WHITE:
+                    await self._hass.async_add_executor_job(self.set_white, v)
+                elif k == ATTR_EFFECT:
+                    await self._hass.async_add_executor_job(self.set_effect, v)
+                elif k == "speed":
+                    await self._hass.async_add_executor_job(self.set_speed, v)
+                else:
+                    _LOGGER.debug("Unknown control key: %s", k)
+            
+            # Handle brightness
+            if brightness_value is not None:
+                if use_brightness_debounce:
+                    # Cancel any pending brightness operation
+                    if self._brightness_task and not self._brightness_task.done():
+                        self._brightness_task.cancel()
+                        try:
+                            await self._brightness_task
+                        except asyncio.CancelledError:
+                            pass
+                    
+                    # Optimistic update for immediate UI feedback
+                    self._state.brightness = brightness_value
+                    self.async_write_ha_state()
+                    
+                    # Debounce brightness changes (for slider dragging)
+                    async def set_brightness_debounced():
+                        try:
+                            await asyncio.sleep(0.2)  # 200ms debounce
+                            await self._hass.async_add_executor_job(self.set_brightness, brightness_value)
+                            await self._sync_state()
+                        except asyncio.CancelledError:
+                            pass
+                    
+                    self._brightness_task = asyncio.create_task(set_brightness_debounced())
+                else:
+                    # Apply immediately (click or combined with other params)
+                    await self._hass.async_add_executor_job(self.set_brightness, brightness_value)
 
-        # Turn on if it was off
-        if was_off:
-            await self._hass.async_add_executor_job(self._toggle_sync)
-        
-        # Schedule an update to get the actual state
-        await self.async_update()
+            # Turn on if it was off
+            if was_off:
+                await self._hass.async_add_executor_job(self._toggle_sync)
+            
+            # Always sync state after operations to get actual device state
+            await self._sync_state()
 
     async def async_turn_off(self, **kwargs):
         """Turn off the light (async)."""
         if self._hass is None:
             return
-        if self._state.is_on:
-            await self._hass.async_add_executor_job(self._toggle_sync)
-            # Schedule an update to get the actual state
-            await self.async_update()
+        
+        async with self._command_lock:
+            # Always sync state first to know actual device state
+            await self._sync_state()
+            
+            if self._state.is_on:
+                await self._hass.async_add_executor_job(self._toggle_sync)
+                # Always sync state after toggle to verify it worked
+                await self._sync_state()
+                
+                # If still on after toggle, try again (device might be slow)
+                if self._state.is_on:
+                    await asyncio.sleep(0.2)
+                    await self._sync_state()
+                    if self._state.is_on:
+                        _LOGGER.warning("Device did not turn off after toggle, trying again")
+                        await self._hass.async_add_executor_job(self._toggle_sync)
+                        await asyncio.sleep(0.2)
+                        await self._sync_state()
 
     def set_segments(self, segments):
         self.send_command(Command.SET_SEGMENT_COUNT, [segments])
@@ -295,7 +354,9 @@ class WifiLedShopLight(LightEntity):
     def extra_state_attributes(self):
         r, g, b = self._state.color
         return {
+            "brightness": self._state.brightness,
             "speed": self._state.speed,
             "default_effect": self._default_effect,
-            "current_rgb": f"rgb({r}, {g}, {b})"
+            "current_rgb": f"rgb({r}, {g}, {b})",
+            "white_value": self._state.white
         }

--- a/pyledshop/WifiLedShopLight.py
+++ b/pyledshop/WifiLedShopLight.py
@@ -1,5 +1,7 @@
 import socket
 import logging
+import asyncio
+from time import sleep
 from .effects import MONO_EFFECTS, PRESET_EFFECTS
 from .constants import Command, CommandFlag
 from .utils import clamp
@@ -15,7 +17,6 @@ from homeassistant.components.light import (
     LightEntity,
 )
 import homeassistant.util.color as color_util
-from time import sleep
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,6 +33,8 @@ class WifiLedShopLight(LightEntity):
         self._retries = retries
         self._state = WifiLedShopLightState()
         self._sock = None
+        self._hass = None  # Will be set by async_added_to_hass
+        self._update_lock = asyncio.Lock()
 
         self._attr_name = name
         self._attr_supported_color_modes = {ColorMode.RGB}
@@ -49,13 +52,7 @@ class WifiLedShopLight(LightEntity):
             # If we can't get the ID, use a fallback based on IP and port
             self._attr_unique_id = f"sp108e_{ip}_{port}"
 
-        # Try to update state, but don't fail initialization if it doesn't work
-        try:
-            self.update()
-        except Exception:
-            # Initial update failed, but we can still create the entity
-            # It will be updated later when HA polls it
-            pass
+        # Don't update during init - let async_added_to_hass handle it
 
     def __enter__(self):
         return self
@@ -65,77 +62,100 @@ class WifiLedShopLight(LightEntity):
 
     def set_color(self, r=0, g=0, b=0):
         r, g, b = clamp(r), clamp(g), clamp(b)
-        self._state.color = (r, g, b)
         self.send_command(Command.SET_COLOR, [r, g, b])
+        # Update state after successful command
+        self._state.color = (r, g, b)
 
     def set_brightness(self, brightness=0):
         brightness = clamp(brightness)
-        self._state.brightness = brightness
         self.send_command(Command.SET_BRIGHTNESS, [brightness])
+        self._state.brightness = brightness
 
     def set_white(self, white=0):
         white = clamp(white)
-        self._state.white = white
         self.send_command(Command.SET_WHITE, [white])
+        self._state.white = white
 
     def set_speed(self, speed=0):
         speed = clamp(speed)
-        self._state.speed = speed
         self.send_command(Command.SET_SPEED, [speed])
+        self._state.speed = speed
 
     def set_effect(self, effect):
         both = {**MONO_EFFECTS, **PRESET_EFFECTS}
         if effect not in both:
+            _LOGGER.warning("Unknown effect: %s", effect)
             return
-        preset = clamp(both[effect])
-        self._state.mode = preset
+        preset = both[effect]
+        # Don't clamp preset values - they can be 0-212
+        # MonoEffect values are 205-212, PRESET_EFFECTS are 0-195
         self.send_command(Command.SET_PRESET, [preset])
+        self._state.mode = preset
 
     def set_custom(self, custom):
         custom = clamp(custom, 1, 12)
         self._state.mode = custom
         self.send_command(Command.SET_CUSTOM, [custom])
 
-    def toggle(self):
-        initial_state = self._state.is_on
+    def _toggle_sync(self):
+        """Toggle the light state (synchronous)."""
         self.send_command(Command.TOGGLE, [])
-        self.update()
-        while initial_state == self._state.is_on:
-            sleep(0.5)
-            self.toggle()
+        # Invert state optimistically - will be corrected by next update
+        self._state.is_on = not self._state.is_on
 
-    def turn_on(self, **kwargs):
-        # Apply defaults if not overridden
-        if ATTR_EFFECT not in kwargs:
-            self.set_effect(self._default_effect)
-        if "speed" not in kwargs:
-            self.set_speed(self._default_speed)
-
+    async def async_turn_on(self, **kwargs):
+        """Turn on the light with optional parameters (async)."""
+        if self._hass is None:
+            return
+        
+        # Only apply defaults if turning on from off state
+        # If already on and just changing color/effect, don't override
+        was_off = not self._state.is_on
+        
+        # If turning on from off, apply defaults first
+        if was_off:
+            if ATTR_EFFECT not in kwargs:
+                await self._hass.async_add_executor_job(
+                    self.set_effect, self._default_effect
+                )
+            if "speed" not in kwargs:
+                await self._hass.async_add_executor_job(
+                    self.set_speed, self._default_speed
+                )
+        
+        # Process all provided parameters
         for k, v in kwargs.items():
             if k == ATTR_BRIGHTNESS:
-                self.set_brightness(v)
+                await self._hass.async_add_executor_job(self.set_brightness, v)
             elif k == "rgb_color":
-                self.set_color(*v)
+                await self._hass.async_add_executor_job(self.set_color, *v)
             elif k == ATTR_HS_COLOR:
                 r, g, b = color_util.color_hs_to_RGB(*v)
-                self.set_color(r, g, b)
+                await self._hass.async_add_executor_job(self.set_color, r, g, b)
             elif k == ATTR_WHITE:
-                self.set_white(v)
+                await self._hass.async_add_executor_job(self.set_white, v)
             elif k == ATTR_EFFECT:
-                self.set_effect(v)
+                await self._hass.async_add_executor_job(self.set_effect, v)
             elif k == "speed":
-                self.set_speed(v)
+                await self._hass.async_add_executor_job(self.set_speed, v)
             else:
-                print(f"unknown control key: {k}")
+                _LOGGER.debug("Unknown control key: %s", k)
 
-        if not self._state.is_on:
-            self.toggle()
+        # Turn on if it was off
+        if was_off:
+            await self._hass.async_add_executor_job(self._toggle_sync)
+        
+        # Schedule an update to get the actual state
+        await self.async_update()
 
-
-
-    def turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs):
+        """Turn off the light (async)."""
+        if self._hass is None:
+            return
         if self._state.is_on:
-            self.toggle()
+            await self._hass.async_add_executor_job(self._toggle_sync)
+            # Schedule an update to get the actual state
+            await self.async_update()
 
     def set_segments(self, segments):
         self.send_command(Command.SET_SEGMENT_COUNT, [segments])
@@ -205,9 +225,30 @@ class WifiLedShopLight(LightEntity):
                     raise ConnectionError(error_msg) from e
 
     def update(self):
+        """Update state from device (synchronous)."""
         response = self.send_command(Command.SYNC, [])
         if response:
             self._state.update_from_sync(bytearray(response))
+
+    async def async_update(self):
+        """Update state from device (async for Home Assistant)."""
+        if self._hass is None:
+            return
+        async with self._update_lock:
+            try:
+                response = await self._hass.async_add_executor_job(
+                    self.send_command, Command.SYNC, []
+                )
+                if response:
+                    self._state.update_from_sync(bytearray(response))
+            except Exception as e:
+                _LOGGER.warning("Failed to update state: %s", e)
+
+    async def async_added_to_hass(self):
+        """Called when entity is added to Home Assistant."""
+        self._hass = self.hass
+        # Do initial update
+        await self.async_update()
 
     def __repr__(self):
         return f"""WifiLedShopLight @ {self._ip}:{self._port}

--- a/pyledshop/constants.py
+++ b/pyledshop/constants.py
@@ -50,14 +50,14 @@ class MonoEffect(IntEnum):
 
   To be used with WifiLedShopLight.set_preset()
   """
-  SOLID = 211,
-  BREATHING = 206,
-  METEOR = 205,
-  FLOW = 208,
-  WAVE = 209,
-  FLASH = 210,
-  STACK = 207,
-  CATCHUP = 212,
+  SOLID = 211
+  BREATHING = 206
+  METEOR = 205
+  FLOW = 208
+  WAVE = 209
+  FLASH = 210
+  STACK = 207
+  CATCHUP = 212
 
 class CustomEffect(IntEnum):
   """
@@ -65,15 +65,15 @@ class CustomEffect(IntEnum):
 
   To be used with WifiLedShopLight.set_custom()
   """
-  CUSTOM_1 = 1,
-  CUSTOM_2 = 2,
-  CUSTOM_3 = 3,
-  CUSTOM_4 = 4,
-  CUSTOM_5 = 5,
-  CUSTOM_6 = 6,
-  CUSTOM_7 = 7,
-  CUSTOM_8 = 8,
-  CUSTOM_9 = 9,
-  CUSTOM_10 = 10,
-  CUSTOM_11 = 11,
-  CUSTOM_12 = 12,
+  CUSTOM_1 = 1
+  CUSTOM_2 = 2
+  CUSTOM_3 = 3
+  CUSTOM_4 = 4
+  CUSTOM_5 = 5
+  CUSTOM_6 = 6
+  CUSTOM_7 = 7
+  CUSTOM_8 = 8
+  CUSTOM_9 = 9
+  CUSTOM_10 = 10
+  CUSTOM_11 = 11
+  CUSTOM_12 = 12


### PR DESCRIPTION
Increase Timeout So Devices Will Connect Instead Of Failing
Reliability Increase On Brigthness changes from HA
Reliability For Turn On/Off, the action is instant no lagging or feedback needed
Added brigthness control from HA Automations
Added Speed Control
Reliably switch between strip off -> preset -> solid color and off solid color -> preset ( meaning regardless of the last color state of the strip, from HA, within an automation, the strip will get the automation color ), however always needs to be passed with Solid (custom color).
Various other improvements and quality of life changes

Not the entire credit goes for me, I had some help from cursor